### PR TITLE
Exploring qt compiling msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Debug/
 .vscode/
 *.exe
 packages/
+build*Debug/

--- a/PotatsCpp/PotatsCpp.sln
+++ b/PotatsCpp/PotatsCpp.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PotatsCpp", "PotatsCpp\Pota
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PotatsCppTests", "PotatsCppTests\PotatsCppTests.vcxproj", "{904CE1D0-2AF2-475F-8594-16CA7BCD9A88}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PotatsCppDllTests", "PotatsCppDllTests\PotatsCppDllTests.vcxproj", "{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -31,6 +33,14 @@ Global
 		{904CE1D0-2AF2-475F-8594-16CA7BCD9A88}.Release|x64.Build.0 = Release|x64
 		{904CE1D0-2AF2-475F-8594-16CA7BCD9A88}.Release|x86.ActiveCfg = Release|Win32
 		{904CE1D0-2AF2-475F-8594-16CA7BCD9A88}.Release|x86.Build.0 = Release|Win32
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Debug|x64.ActiveCfg = Debug|x64
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Debug|x64.Build.0 = Debug|x64
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Debug|x86.ActiveCfg = Debug|Win32
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Debug|x86.Build.0 = Debug|Win32
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Release|x64.ActiveCfg = Release|x64
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Release|x64.Build.0 = Release|x64
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Release|x86.ActiveCfg = Release|Win32
+		{FA87D46A-C438-478C-8B4A-236BDEA4CF7D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PotatsCpp/PotatsCppDllTests/PotatsCppDllTests.vcxproj
+++ b/PotatsCpp/PotatsCppDllTests/PotatsCppDllTests.vcxproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{fa87d46a-c438-478c-8b4a-236bdea4cf7d}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.5\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/PotatsCpp/PotatsCppDllTests/packages.config
+++ b/PotatsCpp/PotatsCppDllTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.5" targetFramework="native" />
+</packages>

--- a/PotatsCpp/PotatsCppDllTests/pch.cpp
+++ b/PotatsCpp/PotatsCppDllTests/pch.cpp
@@ -1,0 +1,5 @@
+//
+// pch.cpp
+//
+
+#include "pch.h"

--- a/PotatsCpp/PotatsCppDllTests/pch.h
+++ b/PotatsCpp/PotatsCppDllTests/pch.h
@@ -1,0 +1,7 @@
+//
+// pch.h
+//
+
+#pragma once
+
+#include "gtest/gtest.h"

--- a/PotatsCpp/PotatsCppDllTests/test.cpp
+++ b/PotatsCpp/PotatsCppDllTests/test.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+
+#include <fstream>
+#include <list>
+#include <string>
+#include <windows.h>
+
+TEST(Tests_PotatsCpp, GivenAPotatsCpp_WhenLoadingTheDll_ThenExternFunctionsCanBeCalled) {
+    HINSTANCE handleToDll = LoadLibrary(TEXT("PotatsCpp.dll"));
+
+    EXPECT_TRUE(handleToDll != nullptr);
+
+    //by default it will load a void (*)(), we don't want that so we cast using (int (*)(int)) to get a function to which an int can be passed and which returns an int
+    auto loadedFunction1 = (int (*)(int))GetProcAddress(handleToDll, "IncrementNumberOf1");
+    EXPECT_TRUE(loadedFunction1 != nullptr);
+
+    auto loadedFunction2 = (std::list<std::string>(*)())GetProcAddress(handleToDll, "GetListOfAlbums");
+    EXPECT_TRUE(loadedFunction2 != nullptr);
+
+    std::ofstream insertTestSourcePathsInSourceFileTxt(".\\sourceFileRepository\\sourceFile.txt");
+    insertTestSourcePathsInSourceFileTxt << "..\\..\\PotatsCppTests\\TestFolderWithFilesEndingWithMp3\\";
+    insertTestSourcePathsInSourceFileTxt.close();
+
+    auto listOfAlbums = loadedFunction2();
+
+    EXPECT_EQ(listOfAlbums.size(), 1);
+
+    for (auto const& albumTitle : listOfAlbums) {
+        EXPECT_GT(albumTitle.size(), 0);
+        EXPECT_LT(albumTitle.size(), 256);
+    }
+}

--- a/PotatsCpp/PotatsCppTests/test.cpp
+++ b/PotatsCpp/PotatsCppTests/test.cpp
@@ -65,6 +65,7 @@ TEST(Tests_PotatsCpp, GivenAPotatsCpp_WhenLoadingTheDll_ThenExternFunctionsCanBe
 
     EXPECT_TRUE(handleToDll != nullptr);
 
+    //by default it will load a void (*)(), we don't want that so we cast using (int (*)(int)) to get a function to which an int can be passed and which returns an int
     auto loadedFunction1 = (int (*)(int))GetProcAddress(handleToDll, "IncrementNumberOf1");
     EXPECT_TRUE(loadedFunction1 != nullptr);
 
@@ -81,5 +82,6 @@ TEST(Tests_PotatsCpp, GivenAPotatsCpp_WhenLoadingTheDll_ThenExternFunctionsCanBe
 
     for (auto const& albumTitle : listOfAlbums) {
         EXPECT_GT(albumTitle.size(), 0);
+        EXPECT_LT(albumTitle.size(), 256);
     }
 }

--- a/PotatsCpp/PotatsCppTests/test.cpp
+++ b/PotatsCpp/PotatsCppTests/test.cpp
@@ -2,9 +2,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <list>
-#include <string>
-#include <windows.h>
 
 #include "../../PotatsCpp/PotatsCpp/MusicLoader.h"
 #include "../../PotatsCpp/PotatsCpp/RepositoryController.h"
@@ -58,30 +55,4 @@ TEST(Tests_MusicLoader, GivenAMusicLoader_WithAPathInSourceFileRepositoryTxtWhic
 
     EXPECT_TRUE(std::filesystem::exists(".\\sourceFileRepository\\"));
     EXPECT_TRUE(std::filesystem::exists(".\\sourceFileRepository\\sourceFile.txt"));
-}
-
-TEST(Tests_PotatsCpp, GivenAPotatsCpp_WhenLoadingTheDll_ThenExternFunctionsCanBeCalled) {
-    HINSTANCE handleToDll = LoadLibrary(TEXT("PotatsCpp.dll"));
-
-    EXPECT_TRUE(handleToDll != nullptr);
-
-    //by default it will load a void (*)(), we don't want that so we cast using (int (*)(int)) to get a function to which an int can be passed and which returns an int
-    auto loadedFunction1 = (int (*)(int))GetProcAddress(handleToDll, "IncrementNumberOf1");
-    EXPECT_TRUE(loadedFunction1 != nullptr);
-
-    auto loadedFunction2 = (std::list<std::string>(*)())GetProcAddress(handleToDll, "GetListOfAlbums");
-    EXPECT_TRUE(loadedFunction2 != nullptr);
-
-    std::ofstream insertTestSourcePathsInSourceFileTxt(".\\sourceFileRepository\\sourceFile.txt");
-    insertTestSourcePathsInSourceFileTxt << "..\\..\\PotatsCppTests\\TestFolderWithFilesEndingWithMp3\\";
-    insertTestSourcePathsInSourceFileTxt.close();
-
-    auto listOfAlbums = loadedFunction2();
-
-    EXPECT_EQ(listOfAlbums.size(), 1);
-
-    for (auto const& albumTitle : listOfAlbums) {
-        EXPECT_GT(albumTitle.size(), 0);
-        EXPECT_LT(albumTitle.size(), 256);
-    }
 }

--- a/PotatsQt/.gitignore
+++ b/PotatsQt/.gitignore
@@ -1,0 +1,73 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/PotatsQt/AddMusicSourceButton.qml
+++ b/PotatsQt/AddMusicSourceButton.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.0
+
+Image {
+    id: root
+    source: "../MusicPlayer/MusicPlayer/Assets/Add.png"
+    signal clicked
+
+    MouseArea{
+        anchors.fill: parent
+        onClicked:  root.clicked()
+    }
+}

--- a/PotatsQt/ApplicationFlow.qml
+++ b/PotatsQt/ApplicationFlow.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.4
+
+ApplicationFlowForm {
+    id: applicationFlow
+    state: "titlePage"
+
+    property int animationDuration: 1000
+
+    SequentialAnimation {
+        id: animateBetweemTitleAndLoading
+        running: true
+        loops: Animation.Infinite
+
+        PropertyAction {
+            targets: applicationFlow
+            properties: "state"
+            value: "titlePage"
+        }
+
+        PauseAnimation {
+            duration: applicationFlow.animationDuration
+        }
+
+        PropertyAction {
+            targets: applicationFlow
+            properties: "state"
+            value: "loadingPage"
+        }
+
+        PauseAnimation {
+            duration: applicationFlow.animationDuration
+        }
+
+        PropertyAction {
+            targets: applicationFlow
+            properties: "state"
+            value: "selectingMusicSourcePage"
+        }
+
+        PauseAnimation {
+            duration: applicationFlow.animationDuration
+        }
+    }
+}

--- a/PotatsQt/ApplicationFlowForm.ui.qml
+++ b/PotatsQt/ApplicationFlowForm.ui.qml
@@ -1,0 +1,68 @@
+import QtQuick 2.4
+
+Item {
+    id: root
+    width: 1200
+    height: 900
+    z: 0
+
+    TitlePage {
+        id: titlePage
+    }
+
+    LoadingPage {
+        id: loadingPage
+    }
+
+    SelectMusicSourcePage {
+        id: selectMusicSourcePage
+    }
+
+    states: [
+        State {
+            name: "titlePage"
+            PropertyChanges {
+                target: titlePage
+                visible: true
+            }
+            PropertyChanges {
+                target: loadingPage
+                visible: false
+            }
+            PropertyChanges {
+                target: selectMusicSourcePage
+                visible: false
+            }
+        },
+        State {
+            name: "loadingPage"
+            PropertyChanges {
+                target: loadingPage
+                visible: true
+            }
+            PropertyChanges {
+                target: titlePage
+                visible: false
+            }
+            PropertyChanges {
+                target: selectMusicSourcePage
+                visible: false
+            }
+        },
+        State {
+            name: "selectingMusicSourcePage"
+            PropertyChanges {
+                target: titlePage
+                visible: false
+            }
+            PropertyChanges {
+                target: loadingPage
+                visible: false
+            }
+            PropertyChanges {
+                target: selectMusicSourcePage
+                visible: true
+            }
+        }
+    ]
+}

--- a/PotatsQt/Background.qml
+++ b/PotatsQt/Background.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Image {
+    id: backgroundApplicationImage
+    source: "../MusicPlayer/MusicPlayer/Assets/WelcomeBackground.png"
+}

--- a/PotatsQt/CMakeLists.txt
+++ b/PotatsQt/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(PotatsQt VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Quick REQUIRED)
+
+set(PROJECT_SOURCES
+        main.cpp
+        qml.qrc
+)
+
+if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    qt_add_executable(PotatsQt
+        MANUAL_FINALIZATION
+        ${PROJECT_SOURCES}
+    )
+# Define target properties for Android with Qt 6 as:
+#    set_property(TARGET PotatsQt APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
+#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
+# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
+else()
+    if(ANDROID)
+        add_library(PotatsQt SHARED
+            ${PROJECT_SOURCES}
+        )
+# Define properties for Android with Qt 5 after find_package() calls as:
+#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
+    else()
+        add_executable(PotatsQt
+          ${PROJECT_SOURCES}
+        )
+    endif()
+endif()
+
+target_compile_definitions(PotatsQt
+  PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
+target_link_libraries(PotatsQt
+  PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Quick)
+
+set_target_properties(PotatsQt PROPERTIES
+    MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
+    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+)
+
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_import_qml_plugins(PotatsQt)
+    qt_finalize_executable(PotatsQt)
+endif()

--- a/PotatsQt/LoadingPage.qml
+++ b/PotatsQt/LoadingPage.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.4
+
+LoadingPageForm {
+    id: loadingPage
+}

--- a/PotatsQt/LoadingPageForm.ui.qml
+++ b/PotatsQt/LoadingPageForm.ui.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.4
+
+Item {
+    width: 1200
+    height: 900
+    z: 0
+
+    Text {
+        x: 400
+        y: 5
+        color: "#f4cb2a"
+        text: qsTr("Loading")
+        font.pointSize: 90
+        z: 2
+        styleColor: "#e4b62d"
+    }
+
+    Background {
+        z: -1
+    }
+
+    PotatsMascot {
+        x: 400
+        y: 300
+        scale: 1.60
+        z: 1
+    }
+}

--- a/PotatsQt/PotatsMascot.qml
+++ b/PotatsQt/PotatsMascot.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Image {
+    id: potatsMascot
+    source: "../MusicPlayer/MusicPlayer/Assets/WelcomePotat.png"
+}

--- a/PotatsQt/SelectMusicSourcePage.qml
+++ b/PotatsQt/SelectMusicSourcePage.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.4
+
+SelectMusicSourcePageForm {
+    id: selectMusicSourcePage
+}

--- a/PotatsQt/SelectMusicSourcePageForm.ui.qml
+++ b/PotatsQt/SelectMusicSourcePageForm.ui.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.4
+
+Item {
+    width: 1200
+    height: 900
+    z: 0
+
+    Text {
+        x: 60
+        y: 5
+        color: "#f4cb2a"
+        text: qsTr("Where is your music located?")
+        font.pointSize: 60
+        z: 2
+        styleColor: "#e4b62d"
+    }
+
+    AddMusicSourceButton {
+        scale: 0.10
+        x: 65
+        y: 150
+        z: 1
+    }
+
+    Background {
+        z: -1
+    }
+}

--- a/PotatsQt/TitlePage.qml
+++ b/PotatsQt/TitlePage.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.4
+
+TitlePageForm {
+    id: titlePage
+}

--- a/PotatsQt/TitlePageForm.ui.qml
+++ b/PotatsQt/TitlePageForm.ui.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.4
+
+Item {
+    width: 1200
+    height: 900
+    z: 0
+
+    Text {
+        x: 70
+        y: 5
+        color: "#f4cb2a"
+        text: qsTr("Potat's Music Player")
+        font.pointSize: 90
+        z: 2
+        styleColor: "#e4b62d"
+    }
+
+    Background {
+        z: -1
+    }
+
+    PotatsMascot {
+        x: 400
+        y: 300
+        scale: 1.6
+        z: 1
+    }
+}

--- a/PotatsQt/main.cpp
+++ b/PotatsQt/main.cpp
@@ -1,0 +1,23 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+
+int main(int argc, char *argv[])
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine;
+    const QUrl url(QStringLiteral("qrc:/main.qml"));
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
+                     &app, [url](QObject *obj, const QUrl &objUrl) {
+        if (!obj && url == objUrl)
+            QCoreApplication::exit(-1);
+    }, Qt::QueuedConnection);
+    engine.load(url);
+
+    return app.exec();
+}

--- a/PotatsQt/main.cpp
+++ b/PotatsQt/main.cpp
@@ -1,12 +1,40 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
+#include <list>
+#include <string>
+#include <windows.h>
 
 int main(int argc, char *argv[])
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+
+    //loading the PotatsCpp library
+    HINSTANCE potatsCppHandle = LoadLibrary(TEXT("PotatsCpp.dll"));
+    if(potatsCppHandle == nullptr)
+    {
+        qDebug() << GetLastError();
+    }
+
+    //by default it will load a void (*)(), we don't want that so we cast using (int (*)(int)) to get a function to which an int can be passed and which returns an int
+    std::string testStringToSee{"super nice string"};
+
+    auto loadedFunction = (int (*)(int))GetProcAddress(potatsCppHandle, "IncrementNumberOf1");
+
+    int a = 4;
+    int b = loadedFunction(a);
+    qDebug() << b;
+
+    auto loadedFunction2 = (std::list<std::string> (*)())GetProcAddress(potatsCppHandle, "GetListOfAlbums");
+
+    auto listOfAlbums = loadedFunction2();
+
+    for(auto const& albumTitle : listOfAlbums){
+        qDebug() << "size of album title : " << albumTitle.size() << '\n';
+    }
+    //end loading
 
     QGuiApplication app(argc, argv);
 

--- a/PotatsQt/main.qml
+++ b/PotatsQt/main.qml
@@ -1,0 +1,9 @@
+import QtQuick
+import QtQuick.Window
+
+Window {
+    width: 640
+    height: 480
+    visible: true
+    title: qsTr("Hello World")
+}

--- a/PotatsQt/main.qml
+++ b/PotatsQt/main.qml
@@ -2,8 +2,12 @@ import QtQuick
 import QtQuick.Window
 
 Window {
-    width: 640
-    height: 480
+    width: 1200
+    height: 900
     visible: true
-    title: qsTr("Hello World")
+    title: qsTr("Potat's Music Player C++")
+
+    ApplicationFlow{
+
+    }
 }

--- a/PotatsQt/qml.qrc
+++ b/PotatsQt/qml.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/PotatsQt/qml.qrc
+++ b/PotatsQt/qml.qrc
@@ -1,5 +1,22 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/Add.png</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/Delete.png</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/Next - Disabled.png</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/Next.png</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/WelcomeBackground.png</file>
+        <file>../MusicPlayer/MusicPlayer/Assets/WelcomePotat.png</file>
+        <file>AddMusicSourceButton.qml</file>
+        <file>ApplicationFlow.qml</file>
+        <file>ApplicationFlowForm.ui.qml</file>
+        <file>Background.qml</file>
+        <file>LoadingPage.qml</file>
+        <file>LoadingPageForm.ui.qml</file>
+        <file>PotatsMascot.qml</file>
+        <file>SelectMusicSourcePage.qml</file>
+        <file>SelectMusicSourcePageForm.ui.qml</file>
+        <file>TitlePage.qml</file>
+        <file>TitlePageForm.ui.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
I created PotatsQt, configured it to be compiled with MSVC 2019 64 bit. 
I added code in PotatsQt main.cpp to load PotatsCpp.dll. It works now since both are compiled with MSVC. (Note that PotatsCpp.dll is compiled with MSVC 2022 64 bit at the moment and VS 2022 is in preview)

In the VS solution for PotatsCpp, I previously had put the test that loads PotatsCpp.dll in the same project as the unit/integration tests which is PotatsCppTests. I moved that test to a new project called PotatsCppDllTests. I configured that new project to compile with C++14 standard and could confirm the test loads successfully the PotatsCpp.dll which is compiled with the most recent C++ features that are available in the compiler that is integrated in VS 2022 preview. (no mangling issues which I understand now it's because it's the same compiler that builds the dll and the test executable. C++ standard version has no impact on the sucess of resolving dll loading and function that we load with GetProcAddress)